### PR TITLE
VIEWER-136 / AnnotationOverlay Props type, 네이밍 개선

### DIFF
--- a/apps/insight-viewer-dev/containers/Annotation/Drawer/index.tsx
+++ b/apps/insight-viewer-dev/containers/Annotation/Drawer/index.tsx
@@ -141,7 +141,7 @@ function AnnotationDrawerContainer(): JSX.Element {
           {loadingState === 'success' && (
             <AnnotationOverlay
               isDrawing={isDrawing}
-              isEditing={isEditing}
+              clickAction={isEditing ? 'select' : 'remove'}
               width={700}
               height={700}
               mode={annotationMode}

--- a/apps/insight-viewer-dev/containers/Measurement/Drawer/index.tsx
+++ b/apps/insight-viewer-dev/containers/Measurement/Drawer/index.tsx
@@ -106,7 +106,7 @@ function MeasurementDrawerContainer(): JSX.Element {
                 onMouseOver={hoverAnnotation}
                 onSelect={selectAnnotation}
                 onRemove={removeAnnotation}
-                isEditing={isEditing}
+                clickAction={isEditing ? 'select' : 'remove'}
                 isDrawing={isDrawing}
                 mode={measurementMode}
                 // If no mode is defined, the default value is ruler.

--- a/libs/insight-viewer/src/Annotation/components/AnnotationDrawer/AnnotationDrawer.types.ts
+++ b/libs/insight-viewer/src/Annotation/components/AnnotationDrawer/AnnotationDrawer.types.ts
@@ -2,8 +2,8 @@ import type { SVGProps } from 'react'
 import type { Annotation, AnnotationMode } from '../../types'
 
 export interface AnnotationDrawerProps extends Omit<SVGProps<SVGSVGElement>, 'onSelect'> {
-  selectedAnnotation: Annotation | null
-  hoveredAnnotation: Annotation | null
+  selectedAnnotation?: Annotation | null
+  hoveredAnnotation?: Annotation | null
   annotations: Annotation[]
 
   isDrawing?: boolean
@@ -16,7 +16,7 @@ export interface AnnotationDrawerProps extends Omit<SVGProps<SVGSVGElement>, 'on
   showAnnotationLabel?: boolean
   /** When drawing is complete and a new annotation occurs */
   onAdd?: (annotation: Annotation) => void
-  onSelect: (annotation: Annotation | null) => void
+  onSelect?: (annotation: Annotation | null) => void
 
   mode?: AnnotationMode
 }

--- a/libs/insight-viewer/src/Annotation/components/AnnotationDrawer/AnnotationDrawer.types.ts
+++ b/libs/insight-viewer/src/Annotation/components/AnnotationDrawer/AnnotationDrawer.types.ts
@@ -1,13 +1,13 @@
 import type { SVGProps } from 'react'
-import type { Annotation, AnnotationMode } from '../../types'
+import type { Annotation, AnnotationMode, ClickAction } from '../../types'
 
 export interface AnnotationDrawerProps extends Omit<SVGProps<SVGSVGElement>, 'onSelect'> {
   selectedAnnotation?: Annotation | null
   hoveredAnnotation?: Annotation | null
   annotations: Annotation[]
 
-  isDrawing?: boolean
-  isEditing?: boolean
+  isDrawing: boolean
+  clickAction: ClickAction
 
   /**
    * annotation label notation flag variable

--- a/libs/insight-viewer/src/Annotation/components/AnnotationDrawer/index.tsx
+++ b/libs/insight-viewer/src/Annotation/components/AnnotationDrawer/index.tsx
@@ -27,8 +27,8 @@ export function AnnotationDrawer({
   style,
   width,
   height,
-  isDrawing = true,
-  isEditing = false,
+  isDrawing,
+  clickAction,
   showAnnotationLabel = false,
   annotations,
   selectedAnnotation,
@@ -39,7 +39,7 @@ export function AnnotationDrawer({
   onSelect,
 }: AnnotationDrawerProps): JSX.Element {
   const svgRef = useRef<SVGSVGElement>(null)
-  const isSelectedAnnotation = Boolean(isEditing && selectedAnnotation)
+  const isSelectedAnnotation = Boolean(clickAction === 'select' && selectedAnnotation)
 
   const [tempAnnotation, setTempAnnotation] = useState<TextAnnotation>()
   const handleTypingFinish = (text: string) => {

--- a/libs/insight-viewer/src/Annotation/components/AnnotationDrawer/index.tsx
+++ b/libs/insight-viewer/src/Annotation/components/AnnotationDrawer/index.tsx
@@ -112,9 +112,13 @@ export function AnnotationDrawer({
         clearDrawingAndMovedPoints()
         return
       }
+
+      if (onSelect) {
+        onSelect(null)
+      }
+
       clearAnnotation()
       clearEditMode()
-      onSelect(null)
       clearDrawingAndMovedPoints()
     },
     addDrewElement: () => {

--- a/libs/insight-viewer/src/Annotation/components/AnnotationOverlay/AnnotationOverlay.types.ts
+++ b/libs/insight-viewer/src/Annotation/components/AnnotationOverlay/AnnotationOverlay.types.ts
@@ -12,14 +12,14 @@ export interface AnnotationOverlayProps {
   showOutline?: boolean
   showAnnotationLabel?: boolean
   mode: AnnotationMode
-  hoveredAnnotation: Annotation | null
-  selectedAnnotation: Annotation | null
+  hoveredAnnotation?: Annotation | null
+  selectedAnnotation?: Annotation | null
   annotations: Annotation[]
 
   onAdd?: (annotation: Annotation) => void
   onClick?: (annotation: Annotation) => void
   onRemove?: (annotation: Annotation) => void
+  onSelect?: (annotation: Annotation | null) => void
   onMouseOver?: (annotation: Annotation | null) => void
-  onSelect: (annotation: Annotation | null) => void
   elementAttrs?: (annotation: Annotation, showOutline: boolean) => SVGProps<SVGPolygonElement>
 }

--- a/libs/insight-viewer/src/Annotation/components/AnnotationOverlay/AnnotationOverlay.types.ts
+++ b/libs/insight-viewer/src/Annotation/components/AnnotationOverlay/AnnotationOverlay.types.ts
@@ -1,6 +1,6 @@
 import type { CSSProperties, SVGProps } from 'react'
 
-import type { Annotation, AnnotationMode } from '../../types'
+import type { Annotation, AnnotationMode, ClickAction } from '../../types'
 
 export interface AnnotationOverlayProps {
   width?: number
@@ -8,7 +8,7 @@ export interface AnnotationOverlayProps {
   className?: string
   style?: CSSProperties
   isDrawing?: boolean
-  isEditing?: boolean
+  clickAction?: ClickAction
   showOutline?: boolean
   showAnnotationLabel?: boolean
   mode: AnnotationMode

--- a/libs/insight-viewer/src/Annotation/components/AnnotationOverlay/index.tsx
+++ b/libs/insight-viewer/src/Annotation/components/AnnotationOverlay/index.tsx
@@ -10,8 +10,8 @@ export const AnnotationOverlay = ({
   height,
   className,
   style,
-  isDrawing,
-  isEditing,
+  isDrawing = false,
+  clickAction = 'remove',
   mode,
   annotations,
   showOutline,
@@ -36,7 +36,7 @@ export const AnnotationOverlay = ({
         showOutline={showOutline}
         showElementLabel={showAnnotationLabel}
         onMouseOver={isDrawing ? onMouseOver : undefined}
-        onClick={isDrawing ? (isEditing ? onSelect : onRemove) : undefined}
+        onClick={isDrawing ? (clickAction === 'select' ? onSelect : onRemove) : undefined}
       />
       <AnnotationDrawer
         width={width}
@@ -48,7 +48,7 @@ export const AnnotationOverlay = ({
         className={className}
         style={style}
         isDrawing={isDrawing}
-        isEditing={isEditing}
+        clickAction={clickAction}
         mode={mode}
         onAdd={onAdd}
         onSelect={onSelect}

--- a/libs/insight-viewer/src/Annotation/components/AnnotationsViewer/AnnotationViewer.types.ts
+++ b/libs/insight-viewer/src/Annotation/components/AnnotationsViewer/AnnotationViewer.types.ts
@@ -8,8 +8,8 @@ export interface AnnotationsViewerProps {
   /** Annotation focused by user interaction such as mouse over */
   annotations: Annotation[]
 
-  hoveredAnnotation: Annotation | null
-  selectedAnnotation: Annotation | null
+  hoveredAnnotation?: Annotation | null
+  selectedAnnotation?: Annotation | null
 
   /** <svg className={}> */
   className?: string

--- a/libs/insight-viewer/src/Annotation/hooks/useCreatingAnnotation/index.ts
+++ b/libs/insight-viewer/src/Annotation/hooks/useCreatingAnnotation/index.ts
@@ -12,7 +12,7 @@ interface UseCreatingAnnotationProps {
   image: Image | null
   editMode: EditMode | null
   mode: AnnotationMode
-  selectedAnnotation: AnnotationType | null
+  selectedAnnotation?: AnnotationType | null
 }
 
 const useCreatingAnnotation = ({ id, mode, image, editMode, selectedAnnotation }: UseCreatingAnnotationProps) => {

--- a/libs/insight-viewer/src/Annotation/types.ts
+++ b/libs/insight-viewer/src/Annotation/types.ts
@@ -3,6 +3,7 @@ import type { CSSProperties } from 'react'
 export type Unit = 'px' | 'mm'
 export type Point = [x: number, y: number]
 export type EditMode = 'startPoint' | 'endPoint' | 'move' | 'textMove'
+export type ClickAction = 'remove' | 'select'
 
 export type ViewerStyleType =
   | 'default'

--- a/libs/insight-viewer/src/hooks/useDrawingHandler/index.ts
+++ b/libs/insight-viewer/src/hooks/useDrawingHandler/index.ts
@@ -72,7 +72,7 @@ function useDrawingHandler({
 
     const activeMouseDrawEvents = () => {
       if (!enabledElement || !enabledElement.element) return
-      if (hoveredDrawing !== null) return
+      if (hoveredDrawing) return
 
       enabledElement.element.addEventListener('mouseup', handleMouseUp)
       enabledElement.element.addEventListener('mouseleave', handleMouseLeave)

--- a/libs/insight-viewer/src/hooks/useDrawingHandler/types.ts
+++ b/libs/insight-viewer/src/hooks/useDrawingHandler/types.ts
@@ -1,4 +1,4 @@
-import { MeasurementMode, AnnotationMode, Point, Measurement, Annotation } from '../../types'
+import { Point, Measurement, Annotation } from '../../types'
 
 export interface UseDrawingHandlerParams {
   svgElement: React.RefObject<SVGSVGElement> | null
@@ -6,5 +6,5 @@ export interface UseDrawingHandlerParams {
   addDrawingPoint: (point: Point) => void
   cancelDrawing: () => void
   addDrewElement: () => void
-  hoveredDrawing: Measurement | Annotation | null
+  hoveredDrawing?: Measurement | Annotation | null
 }


### PR DESCRIPTION
## 📝 Description

AnnotationOverlay onChange 적용 전, 기존 props type 및 네이밍 개선 작업을 진행합니다.
_(onChange 와 함께 올리기엔 수정 사항이 많아 PR 을 분리합니다.)_

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

select, hover 관련 props 는 항상 필수값으로 들어갑니다. 

isEditing props 를 통해 Annotation Remove, Select 기능을 지원합니다.

Issue Number: https://lunit.atlassian.net/browse/VIEWER-136

## 🚀 New behavior

select, hover 관련 props 는 옵셔널입니다. 916f5a8
(사용하지 않을 경우 해당 props 를 넣지 않아도 됩니다.)

ClickAction 타입을 추가합니다. 15d5bad
AnnotationOverlay 에서 Click 시 실행할 액션을 지정합니다.
isEditing 의 대체 prop 이며, 보다 명확한 네이밍을 제공하기 위해 type 과 네이밍을 수정했습니다.

isEditing prop 에서 clickAction 으로 수정합니다. 7ca182e

## 💣 Is this a breaking change?

- [x] Yes
- [ ] No

isEditing 대신 clickAction 을 사용해야합니다.
이와 더불어 boolean 에서 'remove' 혹은 'select' 와 같은 string 타입으로 수정해야합니다.
