### PR TITLE
VIEWER-140 / delete lineHead prop and type

### DIFF
--- a/apps/insight-viewer-dev/containers/Annotation/Drawer/index.tsx
+++ b/apps/insight-viewer-dev/containers/Annotation/Drawer/index.tsx
@@ -1,7 +1,7 @@
 import { useRef, ChangeEvent, useState, useEffect } from 'react'
 import { Box, Switch, Radio, RadioGroup, Stack, Button } from '@chakra-ui/react'
 import { Resizable } from 're-resizable'
-import InsightViewer, { useImage, LineHeadMode } from '@lunit/insight-viewer'
+import InsightViewer, { useImage } from '@lunit/insight-viewer'
 import { useViewport } from '@lunit/insight-viewer/viewport'
 import { AnnotationMode, AnnotationOverlay } from '@lunit/insight-viewer/annotation'
 import { INITIAL_POLYGON_ANNOTATIONS } from '@insight-viewer-library/fixtures'
@@ -27,7 +27,6 @@ function AnnotationDrawerContainer(): JSX.Element {
   const [selectedAnnotation, setSelectedAnnotation] = useState<Annotation | null>(null)
 
   const [annotationMode, setAnnotationMode] = useState<AnnotationMode>('polygon')
-  const [lineHeadMode, setLineHeadMode] = useState<LineHeadMode>('normal')
   const [isDrawing, setIsDrawing] = useState<boolean>(true)
   const [isEditing, setIsEditing] = useState<boolean>(false)
   const [isShowLabel, setIsShowLabel] = useState<boolean>(false)
@@ -67,10 +66,6 @@ function AnnotationDrawerContainer(): JSX.Element {
 
   const handleAnnotationModeClick = (mode: AnnotationMode) => {
     setAnnotationMode(mode)
-  }
-
-  const handleLineHeadModeButtonChange = (lineHead: LineHeadMode) => {
-    setLineHeadMode(lineHead)
   }
 
   const handleEditModeChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -134,13 +129,6 @@ function AnnotationDrawerContainer(): JSX.Element {
           <Radio value="freeLine">Free Line</Radio>
           <Radio value="text">Text</Radio>
           <Radio value="circle">Circle - Not implemented yet</Radio>
-        </Stack>
-      </RadioGroup>
-      <RadioGroup onChange={handleLineHeadModeButtonChange} value={lineHeadMode}>
-        <Stack direction="row">
-          <p style={{ marginRight: '10px' }}>Select Line Head mode - deprecated</p>
-          <Radio value="normal">Normal</Radio>
-          <Radio value="arrow">Arrow</Radio>
         </Stack>
       </RadioGroup>
       <Button data-cy-name="reset-button" size="sm" mb={2} mr={3} colorScheme="blue" onClick={handleResetAnnotation}>

--- a/libs/insight-viewer/src/Annotation/types.ts
+++ b/libs/insight-viewer/src/Annotation/types.ts
@@ -21,9 +21,6 @@ export type ViewerStyle = {
   [styleType in ViewerStyleType]?: CSSProperties
 }
 
-/** @deprecated use arrow line instead */
-export type LineHeadMode = 'normal' | 'arrow'
-
 export type AnnotationMode = 'line' | 'freeLine' | 'polygon' | 'text' | 'arrowLine' | 'ruler' | 'area'
 
 export interface AnnotationBase {

--- a/libs/insight-viewer/src/Viewer/AnnotationDrawer/AnnotationDrawer.types.ts
+++ b/libs/insight-viewer/src/Viewer/AnnotationDrawer/AnnotationDrawer.types.ts
@@ -1,5 +1,5 @@
 import { SVGProps } from 'react'
-import { Annotation, AnnotationMode, LineHeadMode } from '../../types'
+import { Annotation, AnnotationMode } from '../../types'
 
 export interface AnnotationDrawerProps extends SVGProps<SVGSVGElement> {
   selectedAnnotation: Annotation | null
@@ -19,6 +19,4 @@ export interface AnnotationDrawerProps extends SVGProps<SVGSVGElement> {
   onSelectAnnotation: (annotation: Annotation | null) => void
 
   mode?: AnnotationMode
-  /** @deprecated use arrow line instead */
-  lineHead?: LineHeadMode
 }

--- a/libs/insight-viewer/src/Viewer/AnnotationDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/AnnotationDrawer/index.tsx
@@ -22,7 +22,6 @@ export function AnnotationDrawer({
   hoveredAnnotation,
   onSelectAnnotation,
   className,
-  lineHead = 'normal',
   mode = 'polygon',
   onAdd,
 }: AnnotationDrawerProps): JSX.Element {
@@ -39,7 +38,6 @@ export function AnnotationDrawer({
     isDrawing,
     isEditing,
     mode,
-    lineHead,
     annotations,
     selectedAnnotation,
     onSelectAnnotation,
@@ -90,7 +88,6 @@ export function AnnotationDrawer({
               isSelectedMode={isSelectedAnnotation}
               showAnnotationLabel={showAnnotationLabel}
               isPolygonSelected={selectedAnnotation?.type === 'polygon'}
-              lineHead={lineHead}
               selectedAnnotationLabel={selectedAnnotation ? selectedAnnotation.label ?? selectedAnnotation.id : null}
               setAnnotationEditMode={setAnnotationEditMode}
               cursorStatus={cursorStatus}

--- a/libs/insight-viewer/src/Viewer/AnnotationOverlay/AnnotationOverlay.types.ts
+++ b/libs/insight-viewer/src/Viewer/AnnotationOverlay/AnnotationOverlay.types.ts
@@ -1,16 +1,10 @@
-import { Annotation, AnnotationMode, LineHeadMode } from '../../types'
+import { Annotation, AnnotationMode } from '../../types'
 import { AnnotationViewerProps } from '../AnnotationViewer/AnnotationViewer.types'
 
 export interface AnnotationOverlayProps extends AnnotationViewerProps {
   isDrawing?: boolean
   mode?: AnnotationMode
   selectedAnnotation: Annotation | null
-  /**
-   *  normal has no head
-   *  For arrow, an arrow head is added.
-   * @deprecated use arrow line instead
-   */
-  lineHead?: LineHeadMode
   onFocus?: (annotation: Annotation | null) => void
   onAdd?: (annotation: Annotation) => void
   onRemove?: (annotation: Annotation) => void

--- a/libs/insight-viewer/src/Viewer/AnnotationOverlay/index.tsx
+++ b/libs/insight-viewer/src/Viewer/AnnotationOverlay/index.tsx
@@ -15,7 +15,6 @@ export function AnnotationOverlay({
   showOutline,
   showAnnotationLabel,
   mode,
-  lineHead,
   isDrawing = false,
   isEditing,
   annotationAttrs,
@@ -57,7 +56,6 @@ export function AnnotationOverlay({
           isDrawing={isDrawing}
           isEditing={isEditing}
           mode={mode}
-          lineHead={lineHead}
           onAdd={onAdd}
           onSelectAnnotation={onSelect}
         />

--- a/libs/insight-viewer/src/Viewer/PolylineDrawer/PolylineDrawer.types.ts
+++ b/libs/insight-viewer/src/Viewer/PolylineDrawer/PolylineDrawer.types.ts
@@ -1,5 +1,4 @@
 import type {
-  LineHeadMode,
   EditMode,
   PolygonAnnotation,
   FreeLineAnnotation,
@@ -11,8 +10,6 @@ import type {
 export interface PolylineDrawerProps {
   annotation: PolygonAnnotation | FreeLineAnnotation | LineAnnotation | ArrowLineAnnotation
   isSelectedMode: boolean
-  /** @deprecated use arrow line instead */
-  lineHead: LineHeadMode
   showAnnotationLabel: boolean
   selectedAnnotationLabel: string | number | null
   setAnnotationEditMode: (mode: EditMode) => void

--- a/libs/insight-viewer/src/Viewer/PolylineDrawer/index.tsx
+++ b/libs/insight-viewer/src/Viewer/PolylineDrawer/index.tsx
@@ -15,7 +15,6 @@ const PolylineElement = ({
 
 export function PolylineDrawer({
   annotation,
-  lineHead,
   isSelectedMode,
   selectedAnnotationLabel,
   showAnnotationLabel,
@@ -56,7 +55,7 @@ export function PolylineDrawer({
       {points && points.length > 0 && (
         <>
           <PolylineElement isPolygon={isPolygonSelected} style={svgWrapperStyle.outline} points={polylinePoints} />
-          {(lineHead === 'arrow' || type === 'arrowLine') && (
+          {type === 'arrowLine' && (
             <>
               <PolylineElement
                 className={`annotation-polyline ${cursorClassName} `}

--- a/libs/insight-viewer/src/hooks/useAnnotationPointsHandler/index.ts
+++ b/libs/insight-viewer/src/hooks/useAnnotationPointsHandler/index.ts
@@ -18,7 +18,6 @@ export default function useAnnotationPointsHandler({
   mode,
   isDrawing,
   isEditing,
-  lineHead,
   svgElement,
   annotations,
   selectedAnnotation,

--- a/libs/insight-viewer/src/hooks/useAnnotationPointsHandler/types.ts
+++ b/libs/insight-viewer/src/hooks/useAnnotationPointsHandler/types.ts
@@ -1,12 +1,10 @@
-import type { AnnotationMode, Annotation, LineHeadMode, EditMode, CursorStatus } from '../../types'
+import type { AnnotationMode, Annotation, EditMode, CursorStatus } from '../../types'
 import type { EditPoints } from '../../utils/common/getEditPointPosition'
 
 export interface UseAnnotationPointsHandlerParams {
   isDrawing: boolean
   isEditing: boolean
   mode: AnnotationMode
-  /** @deprecated use arrow line instead */
-  lineHead: LineHeadMode
   annotations: Annotation[]
   selectedAnnotation: Annotation | null
   hoveredAnnotation: Annotation | null

--- a/libs/insight-viewer/src/hooks/useAnnotationPointsHandler/utils/getInitialAnnotation.ts
+++ b/libs/insight-viewer/src/hooks/useAnnotationPointsHandler/utils/getInitialAnnotation.ts
@@ -3,7 +3,7 @@ import polylabel from 'polylabel'
 import { LINE_TEXT_POSITION_SPACING } from '../../../const'
 
 import type { Image } from '../../../Viewer/types'
-import type { Point, LineHeadMode, AnnotationMode, Annotation } from '../../../types'
+import type { Point, AnnotationMode, Annotation } from '../../../types'
 
 import { getCircleRadiusByMeasuringUnit } from '../../../utils/common/getCircleRadius'
 

--- a/libs/insight-viewer/src/index.ts
+++ b/libs/insight-viewer/src/index.ts
@@ -22,7 +22,6 @@ export type {
   Contours,
   Annotation,
   Point,
-  LineHeadMode,
   AnnotationBase,
   PolygonAnnotation,
   LineAnnotation,

--- a/libs/insight-viewer/src/types/index.ts
+++ b/libs/insight-viewer/src/types/index.ts
@@ -82,8 +82,6 @@ export type ViewerStyle = {
   [styleType in ViewerStyleType]?: CSSProperties
 }
 
-/** @deprecated use arrow line instead */
-export type LineHeadMode = 'normal' | 'arrow'
 export type AnnotationMode = 'line' | 'freeLine' | 'polygon' | 'circle' | 'text' | 'arrowLine'
 
 export interface AnnotationBase {


### PR DESCRIPTION
## 📝 Description

사용하지 않는 LineHead prop 및 관련 타입, 로직을 삭제합니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [x] Other... Please describe: delete sub feature

## 🎯 Current behavior

lineHead prop 을 통해 Line Annotation, Arrow Annotation 선택을 할 수 있습니다.

Issue Number: https://lunit.atlassian.net/browse/VIEWER-140

## 🚀 New behavior

Annotation type 및 mode prop 을 통해 Line, Arrow 를 구분합니다.
lineHead 는 더이상 사용할 수 없습니다.

## 💣 Is this a breaking change?

- [x] Yes
- [ ] No

`lineHead` 를 사용하는 대신 mode prop 의 `arrowLine` 을 사용해야합니다.
