### PR TITLE
VIEWER-156 / useViewport hook parameter type

### DIFF
--- a/apps/insight-viewer-dev/containers/Annotation/Drawer/index.tsx
+++ b/apps/insight-viewer-dev/containers/Annotation/Drawer/index.tsx
@@ -40,7 +40,7 @@ function AnnotationDrawerContainer(): JSX.Element {
   })
   const { viewport, setViewport } = useViewport({
     image,
-    element: viewerRef.current,
+    viewerRef,
   })
 
   const handleAnnotationsChange = (annotations: Annotation[]) => {

--- a/apps/insight-viewer-dev/containers/Interaction/Code.ts
+++ b/apps/insight-viewer-dev/containers/Interaction/Code.ts
@@ -27,7 +27,7 @@ export default function App(): JSX.Element {
 
   const { viewport, setViewport, resetViewport } = useViewport({
     image: images[frame],
-    element: viewerRef.current,
+    viewerRef,
     getInitialViewport: (prevViewport) => ({ ...prevViewport, scale: 1 }),
   })
 
@@ -177,7 +177,7 @@ export default function App(): JSX.Element {
 
   const { viewport, setViewport, resetViewport } = useViewport({
     image: images[frame],
-    element: viewerRef.current,
+    viewerRef,
     getInitialViewport: (prevViewport) => ({ ...prevViewport, scale: 1 }),
   })
 

--- a/apps/insight-viewer-dev/containers/Interaction/Custom.tsx
+++ b/apps/insight-viewer-dev/containers/Interaction/Custom.tsx
@@ -11,8 +11,7 @@ import ClickControl from './Control/Click'
 import OverlayLayer from '../../components/OverlayLayer'
 import CustomProgress from '../../components/CustomProgress'
 import { ViewerWrapper } from '../../components/Wrapper'
-import { BASE_CODE, CUSTOM_CODE } from './Code'
-import { CODE_SANDBOX } from '../../const'
+import { CUSTOM_CODE } from './Code'
 
 export default function App(): JSX.Element {
   const viewerRef = useRef<HTMLDivElement>(null)
@@ -32,7 +31,7 @@ export default function App(): JSX.Element {
     resetViewport,
   } = useViewport({
     image,
-    element: viewerRef.current,
+    viewerRef,
     getInitialViewport: (prevViewport) => ({ ...prevViewport, scale: 1 }),
   })
 

--- a/apps/insight-viewer-dev/containers/Interaction/Image1.tsx
+++ b/apps/insight-viewer-dev/containers/Interaction/Image1.tsx
@@ -48,7 +48,7 @@ export default function App(): JSX.Element {
   const { viewport, setViewport, resetViewport } = useViewport({
     ...viewportSetting,
     image: images[frame],
-    element: viewerRef.current,
+    viewerRef,
     getInitialViewport: (prevViewport) => ({ ...prevViewport, scale: 1 }),
   })
 

--- a/apps/insight-viewer-dev/containers/Overlay/Code.ts
+++ b/apps/insight-viewer-dev/containers/Overlay/Code.ts
@@ -28,7 +28,7 @@ export const CODE = `\
 
     const { viewport, setViewport } = useViewport({
       image,
-      element: viewerRef.current,
+      viewerRef,
     })
 
     return (

--- a/apps/insight-viewer-dev/containers/Overlay/index.tsx
+++ b/apps/insight-viewer-dev/containers/Overlay/index.tsx
@@ -18,7 +18,7 @@ function Overlay(): JSX.Element {
   })
   const { viewport, setViewport } = useViewport({
     image,
-    element: viewerRef.current,
+    viewerRef,
   })
 
   return (

--- a/apps/insight-viewer-dev/containers/UseOverlayContext/Contour/index.tsx
+++ b/apps/insight-viewer-dev/containers/UseOverlayContext/Contour/index.tsx
@@ -20,7 +20,7 @@ function ContourContainer(): JSX.Element {
   })
   const { viewport, setViewport } = useViewport({
     image,
-    element: viewerRef.current,
+    viewerRef,
   })
   const { interaction } = useInteraction({
     primaryDrag: 'pan',

--- a/apps/insight-viewer-dev/containers/UseOverlayContext/Heatmap/index.tsx
+++ b/apps/insight-viewer-dev/containers/UseOverlayContext/Heatmap/index.tsx
@@ -22,7 +22,7 @@ function HeatmapContainer(): JSX.Element {
   })
   const { viewport, setViewport } = useViewport({
     image,
-    element: viewerRef.current,
+    viewerRef,
   })
   const { interaction } = useInteraction({
     primaryDrag: 'pan',

--- a/apps/insight-viewer-dev/containers/Viewport/Code.ts
+++ b/apps/insight-viewer-dev/containers/Viewport/Code.ts
@@ -1,9 +1,6 @@
 export const CODE = `\
 import { useRef, useEffect, useCallback } from 'react'
-import InsightViewer, {
-  useImage,
-  useViewport,
-} from '@lunit/insight-viewer'
+import InsightViewer, { useImage } from '@lunit/insight-viewer'
 import { useViewport } from '@lunit/insight-viewer/viewport'
 
 import type { Viewport } from '@lunit/insight-viewer'
@@ -22,7 +19,7 @@ export default function App() {
 
   const { viewport, setViewport, resetViewport, initialized } = useViewport({
     image,
-    element: viewerRef.current,
+    viewerRef,
     options: { fitScale: false },
     getInitialViewport: (prevViewport) => ({ ...prevViewport, ...INITIAL_VIEWPORT1 }),
   })

--- a/apps/insight-viewer-dev/containers/Viewport/Image1.tsx
+++ b/apps/insight-viewer-dev/containers/Viewport/Image1.tsx
@@ -17,7 +17,7 @@ export default function Image1(): JSX.Element {
   })
   const { viewport, setViewport, resetViewport, initialized } = useViewport({
     image,
-    element: viewerRef.current,
+    viewerRef,
     options: { fitScale: false },
     getInitialViewport: (prevViewport) => ({ ...prevViewport, ...INITIAL_VIEWPORT1 }),
   })

--- a/apps/insight-viewer-dev/containers/Viewport/Image2.tsx
+++ b/apps/insight-viewer-dev/containers/Viewport/Image2.tsx
@@ -16,7 +16,7 @@ export default function Image2(): JSX.Element {
   })
   const { viewport, setViewport, resetViewport } = useViewport({
     image,
-    element: viewerRef.current,
+    viewerRef,
     options: { fitScale: false },
     getInitialViewport: (prevViewport) => ({ ...prevViewport, ...INITIAL_VIEWPORT2 }),
   })

--- a/apps/insight-viewer-dev/containers/ViewportReset/MultiFrame/Code.ts
+++ b/apps/insight-viewer-dev/containers/ViewportReset/MultiFrame/Code.ts
@@ -19,7 +19,7 @@ export default function Viewer() {
 
   const { viewport, setViewport, resetViewport } = useViewport({
     image,
-    element: viewerRef.current,
+    viewerRef,
     options: { fitScale: false },
     getInitialViewport: (prevViewport) => ({ ...prevViewport, ...INITIAL_VIEWPORT }),
   })

--- a/apps/insight-viewer-dev/containers/ViewportReset/MultiFrame/Images.tsx
+++ b/apps/insight-viewer-dev/containers/ViewportReset/MultiFrame/Images.tsx
@@ -30,7 +30,7 @@ export default function Images(): JSX.Element {
 
   const { viewport, setViewport, resetViewport } = useViewport({
     image: images[frame],
-    element: viewerRef.current,
+    viewerRef,
     options: { fitScale: false },
     getInitialViewport: (prevViewport) => ({ ...prevViewport, ...INITIAL_VIEWPORT }),
   })

--- a/apps/insight-viewer-dev/containers/ViewportReset/SingleFrame/Code.ts
+++ b/apps/insight-viewer-dev/containers/ViewportReset/SingleFrame/Code.ts
@@ -15,7 +15,7 @@ export default function Viewer() {
 
   const { viewport, setViewport, resetViewport } = useViewport({
     image,
-    element: viewerRef.current,
+    viewerRef,
     options: { fitScale: false },
     getInitialViewport: (prevViewport) => ({ ...prevViewport, ...INITIAL_VIEWPORT }),
   })
@@ -75,7 +75,7 @@ export default function Viewer() {
 
   const { viewport, setViewport, resetViewport, initialized } = useViewport({
     image,
-    element: viewerRef.current,
+    viewerRef,
     options: { fitScale: false },
     getInitialViewport: (prevViewport) => ({ ...prevViewport, ...(currentViewportRef.current ?? INITIAL_VIEWPORT) }),
   })

--- a/apps/insight-viewer-dev/containers/ViewportReset/SingleFrame/Image1.tsx
+++ b/apps/insight-viewer-dev/containers/ViewportReset/SingleFrame/Image1.tsx
@@ -25,7 +25,7 @@ export default function Image1(): JSX.Element {
   })
   const { viewport, setViewport, resetViewport, initialized } = useViewport({
     image,
-    element: viewerRef.current,
+    viewerRef,
     options: { fitScale: false },
     getInitialViewport: (prevViewport) => ({ ...prevViewport, ...INITIAL_VIEWPORT }),
   })

--- a/apps/insight-viewer-dev/containers/ViewportReset/SingleFrame/Image2.tsx
+++ b/apps/insight-viewer-dev/containers/ViewportReset/SingleFrame/Image2.tsx
@@ -27,7 +27,7 @@ export default function Image2(): JSX.Element {
 
   const { viewport, initialized, setViewport, resetViewport } = useViewport({
     image,
-    element: viewerRef.current,
+    viewerRef,
     options: { fitScale: false },
     getInitialViewport: (prevViewport) => ({ ...prevViewport, ...(currentViewportRef.current ?? INITIAL_VIEWPORT) }),
   })

--- a/libs/insight-viewer/src/const/index.ts
+++ b/libs/insight-viewer/src/const/index.ts
@@ -44,6 +44,10 @@ export const DEFAULT_VIEWPORT_OPTIONS = {
   fitScale: true,
 }
 
+export const DEFAULT_VIEWPORT_VIEWER_REF = {
+  current: null,
+}
+
 export const ERROR_MESSAGE = {
   ENABLED_ELEMENT_NOT_READY: 'enabledElement value is null, Please check the enabledElement value.',
 } as const

--- a/libs/viewport/src/useViewport/index.ts
+++ b/libs/viewport/src/useViewport/index.ts
@@ -3,7 +3,12 @@
  */
 import { useState, useEffect, useCallback, useRef } from 'react'
 
-import { cornerstoneHelper, BASE_VIEWPORT, DEFAULT_VIEWPORT_OPTIONS } from '@lunit/insight-viewer'
+import {
+  cornerstoneHelper,
+  BASE_VIEWPORT,
+  DEFAULT_VIEWPORT_OPTIONS,
+  DEFAULT_VIEWPORT_VIEWER_REF,
+} from '@lunit/insight-viewer'
 
 import type { Image, Viewport } from '@lunit/insight-viewer'
 import type { SetViewportAction, UseViewportReturnType, UseViewportParams } from './type'
@@ -39,7 +44,7 @@ const getViewportWithFitScaleOption = (
 export function useViewport(
   { image, viewerRef, options = DEFAULT_VIEWPORT_OPTIONS, getInitialViewport }: UseViewportParams = {
     image: undefined,
-    viewerRef: { current: null },
+    viewerRef: DEFAULT_VIEWPORT_VIEWER_REF,
     options: DEFAULT_VIEWPORT_OPTIONS,
   }
 ): UseViewportReturnType {

--- a/libs/viewport/src/useViewport/index.ts
+++ b/libs/viewport/src/useViewport/index.ts
@@ -48,15 +48,12 @@ export function useViewport(
     _viewportOptions: options,
   })
 
-  const element = viewerRef.current
-
   const imageRef = useRef(image)
-  const elementRef = useRef(element)
   const getInitialViewportRef = useRef(getInitialViewport)
   const imageSeriesKeyRef = useRef<string | undefined>()
 
   const resetViewport = useCallback(() => {
-    const defaultViewport = getDefaultViewport(imageRef.current, elementRef.current)
+    const defaultViewport = getDefaultViewport(imageRef.current, viewerRef.current)
 
     if (!defaultViewport) {
       setViewport({
@@ -82,22 +79,26 @@ export function useViewport(
     } else {
       setViewport({ ...defaultViewport, _viewportOptions: options })
     }
-  }, [getInitialViewport, options])
+  }, [getInitialViewport, options, viewerRef])
 
   /**
    * We assigned the function type and the value type
    * for the immediate viewport assignment as union type
    * to utilize the previous viewport.
    */
-  const setViewportWithValidation = useCallback((setViewportAction: SetViewportAction) => {
-    setViewport((prevViewport) => {
-      const newViewport = typeof setViewportAction === 'function' ? setViewportAction(prevViewport) : setViewportAction
+  const setViewportWithValidation = useCallback(
+    (setViewportAction: SetViewportAction) => {
+      setViewport((prevViewport) => {
+        const newViewport =
+          typeof setViewportAction === 'function' ? setViewportAction(prevViewport) : setViewportAction
 
-      const updatedViewport = getViewportWithFitScaleOption(newViewport, imageRef.current, elementRef.current)
+        const updatedViewport = getViewportWithFitScaleOption(newViewport, imageRef.current, viewerRef.current)
 
-      return updatedViewport
-    })
-  }, [])
+        return updatedViewport
+      })
+    },
+    [viewerRef]
+  )
 
   useEffect(() => {
     setViewportWithValidation((prevViewport) => ({ ...prevViewport, _viewportOptions: { fitScale: options.fitScale } }))
@@ -105,15 +106,14 @@ export function useViewport(
 
   useEffect(() => {
     imageRef.current = image
-    elementRef.current = element
-  }, [image, element])
+  }, [image])
 
   /**
    * The purpose of setting the initial Viewport value
    * when the image is changed
    */
   useEffect(() => {
-    const defaultViewport = getDefaultViewport(imageRef.current, elementRef.current)
+    const defaultViewport = getDefaultViewport(imageRef.current, viewerRef.current)
 
     if (!defaultViewport) return
 
@@ -135,7 +135,7 @@ export function useViewport(
       ...initialViewport,
       _viewportOptions: prevViewport._viewportOptions,
     }))
-  }, [image, element, getInitialViewportRef])
+  }, [image, viewerRef, getInitialViewportRef])
 
   return {
     viewport,

--- a/libs/viewport/src/useViewport/index.ts
+++ b/libs/viewport/src/useViewport/index.ts
@@ -10,7 +10,7 @@ import type { SetViewportAction, UseViewportReturnType, UseViewportParams } from
 
 const { formatViewerViewport, getDefaultViewportForImage } = cornerstoneHelper
 
-const getDefaultViewport = (image: Image | undefined, element: HTMLDivElement | undefined) => {
+const getDefaultViewport = (image: Image | undefined, element: HTMLDivElement | null) => {
   if (!image || !element) return null
 
   const defaultViewport = getDefaultViewportForImage(element, image)
@@ -21,7 +21,7 @@ const getDefaultViewport = (image: Image | undefined, element: HTMLDivElement | 
 const getViewportWithFitScaleOption = (
   viewport: Viewport,
   image: Image | undefined,
-  element: HTMLDivElement | undefined
+  element: HTMLDivElement | null
 ): Viewport => {
   const defaultViewport = getDefaultViewport(image, element)
 
@@ -37,9 +37,9 @@ const getViewportWithFitScaleOption = (
 }
 
 export function useViewport(
-  { image, element, options = DEFAULT_VIEWPORT_OPTIONS, getInitialViewport }: UseViewportParams = {
+  { image, viewerRef, options = DEFAULT_VIEWPORT_OPTIONS, getInitialViewport }: UseViewportParams = {
     image: undefined,
-    element: undefined,
+    viewerRef: { current: null },
     options: DEFAULT_VIEWPORT_OPTIONS,
   }
 ): UseViewportReturnType {
@@ -47,6 +47,8 @@ export function useViewport(
     ...BASE_VIEWPORT,
     _viewportOptions: options,
   })
+
+  const element = viewerRef.current
 
   const imageRef = useRef(image)
   const elementRef = useRef(element)

--- a/libs/viewport/src/useViewport/type.ts
+++ b/libs/viewport/src/useViewport/type.ts
@@ -1,8 +1,9 @@
+import type { MutableRefObject } from 'react'
 import type { Image, Viewport, ViewportOptions } from '@lunit/insight-viewer'
 
 export interface UseViewportParams {
   image: Image | undefined
-  element: HTMLDivElement | undefined
+  viewerRef: MutableRefObject<HTMLDivElement | null>
   options?: ViewportOptions
   getInitialViewport?: (defaultViewport: Viewport) => Viewport
 }
@@ -11,7 +12,7 @@ export interface UseViewportReturnType {
   viewport: Viewport
   initialized: boolean
   resetViewport: () => void
-  getDefaultViewport: (image: Image | undefined, element: HTMLDivElement | undefined) => void
+  getDefaultViewport: (image: Image | undefined, element: HTMLDivElement | null) => void
   setViewport: (setViewportAction: SetViewportAction) => void
 }
 


### PR DESCRIPTION
## 📝 Description

useViewport hook 의 element 받는 방식을 `ref.current` 가 아닌 ref 그 자체를 받는 방향으로 수정합니다.
이는 InsightViewer Component 의 prop 와 통일된 방식을 제공하기 위함입니다.

또한 기존 `HTMLDivElement | undefined` 타입에서 `HTMLDivElement | null` 타입으로 변경합니다.
이 역시도 InsightViewer Component prop 의 타입과 동일하게 제공하기 위함입니다.
_(이 부분 때문에 타입 에러가 발생하는 것을 수정합니다.)_

## ✔️ PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

useViewport hook 에서 `HTMLDivElement | undefined` 타입을 받습니다.

ref.current 을 인자로 받습니다.

Issue Number: https://lunit.atlassian.net/browse/VIEWER-156

## 🚀 New behavior

useViewport hook 에서 `HTMLDivElement | null` 타입을 받습니다.

ref 자체를 인자로 받습니다.

## 💣 Is this a breaking change?

- [x] Yes
- [ ] No

useViewport hook 의 parameter 가 변경되어 수정이 필요합니다.
