### PR TITLE
VIEWER-159 / drag event 실행 영역 제한 및 개선

### DIFF
--- a/.github/workflows/insight-viewer-feature.yml
+++ b/.github/workflows/insight-viewer-feature.yml
@@ -44,3 +44,5 @@ jobs:
         with:
           file: 'comment.md'
           github_token: ${{secrets.GITHUB_TOKEN}}
+        env:
+          PR_ID: ${{github.event.number}}

--- a/libs/insight-viewer/src/hooks/useInteraction/useHandleDrag/index.ts
+++ b/libs/insight-viewer/src/hooks/useInteraction/useHandleDrag/index.ts
@@ -115,9 +115,9 @@ export default function useHandleDrag({ image, element, interaction, onViewportC
     if (!(interaction[PRIMARY_DRAG] || interaction[SECONDARY_DRAG])) return undefined
 
     const mousedown$ = fromEvent<MouseEvent>(<HTMLDivElement>element, 'mousedown')
-    const mousemove$ = fromEvent<MouseEvent>(<HTMLDivElement>element, 'mousemove')
-    const mouseup$ = fromEvent<MouseEvent>(<HTMLDivElement>element, 'mouseup')
-    const mouseleave$ = fromEvent<MouseEvent>(<HTMLDivElement>element, 'mouseleave')
+    const mousemove$ = fromEvent<MouseEvent>(document, 'mousemove')
+    const mouseup$ = fromEvent<MouseEvent>(document, 'mouseup')
+    const mouseleave$ = fromEvent<MouseEvent>(document, 'mouseleave')
     let dragType: DragType | undefined
 
     subscriptionRef.current = mousedown$
@@ -156,7 +156,7 @@ export default function useHandleDrag({ image, element, interaction, onViewportC
                 deltaY,
               }
             }),
-            takeUntil(merge(mouseup$, mouseleave$))
+            takeUntil(mouseup$)
           )
         })
       )

--- a/libs/insight-viewer/src/hooks/useInteraction/useHandleDrag/index.ts
+++ b/libs/insight-viewer/src/hooks/useInteraction/useHandleDrag/index.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { fromEvent, tap, switchMap, map, takeUntil, filter, Subscription } from 'rxjs'
+import { fromEvent, tap, switchMap, map, takeUntil, filter, Subscription, merge } from 'rxjs'
 import { Element, OnViewportChange } from '../../../types'
 import { formatCornerstoneViewport } from '../../../utils/cornerstoneHelper/formatViewport'
 import {
@@ -117,6 +117,7 @@ export default function useHandleDrag({ image, element, interaction, onViewportC
     const mousedown$ = fromEvent<MouseEvent>(<HTMLDivElement>element, 'mousedown')
     const mousemove$ = fromEvent<MouseEvent>(<HTMLDivElement>element, 'mousemove')
     const mouseup$ = fromEvent<MouseEvent>(<HTMLDivElement>element, 'mouseup')
+    const mouseleave$ = fromEvent<MouseEvent>(<HTMLDivElement>element, 'mouseleave')
     let dragType: DragType | undefined
 
     subscriptionRef.current = mousedown$
@@ -155,7 +156,7 @@ export default function useHandleDrag({ image, element, interaction, onViewportC
                 deltaY,
               }
             }),
-            takeUntil(mouseup$)
+            takeUntil(merge(mouseup$, mouseleave$))
           )
         })
       )

--- a/libs/insight-viewer/src/hooks/useInteraction/useHandleDrag/index.ts
+++ b/libs/insight-viewer/src/hooks/useInteraction/useHandleDrag/index.ts
@@ -156,7 +156,7 @@ export default function useHandleDrag({ image, element, interaction, onViewportC
                 deltaY,
               }
             }),
-            takeUntil(mouseup$)
+            takeUntil(merge(mouseup$, mouseleave$))
           )
         })
       )

--- a/libs/insight-viewer/src/hooks/useInteraction/useHandleDrag/index.ts
+++ b/libs/insight-viewer/src/hooks/useInteraction/useHandleDrag/index.ts
@@ -115,8 +115,8 @@ export default function useHandleDrag({ image, element, interaction, onViewportC
     if (!(interaction[PRIMARY_DRAG] || interaction[SECONDARY_DRAG])) return undefined
 
     const mousedown$ = fromEvent<MouseEvent>(<HTMLDivElement>element, 'mousedown')
-    const mousemove$ = fromEvent<MouseEvent>(document, 'mousemove')
-    const mouseup$ = fromEvent<MouseEvent>(document, 'mouseup')
+    const mousemove$ = fromEvent<MouseEvent>(<HTMLDivElement>element, 'mousemove')
+    const mouseup$ = fromEvent<MouseEvent>(<HTMLDivElement>element, 'mouseup')
     let dragType: DragType | undefined
 
     subscriptionRef.current = mousedown$


### PR DESCRIPTION
## 📝 Description

drag interaction 의 이벤트 실행 범위를 `document(브라우저 전체 영역)` 에서
`insight viewer element(viewer 영역)` 으로 제한합니다.

위 조치는 Annotation Drawing 과 동일한 영역을 제공하여 사용자에게 혼동을 줄이기 위함입니다.
_(또한 예상치 못한 동작을 방지하기 위한 목적도 있습니다.)_

이 과정에서 viewer element 영역을 벗어날 경우, mouse move 에 대한 observable 이 끊기도록
mouse leave observable 추가 및 `takeUntil` 에 mouse leave 를 추가하여
mouse up, mouse event 일 때 mouse move observable 이 끊기도록 수정했습니다. 

위 조치를 하지 않을 경우 아래와 같은 버그가 발생합니다. 

1. viewer 영역 내에서 mouse move 를 통해 drag interaction 실행(영상 이미지 움직임)
2. viewer 영역을 벗어난 후 mouse up (영상 이미지 움직이지 않음)
3. viewer 영역으로 복귀하여 mouse move (영상 이미지 다시 움직임)

drag (mouse down -> mouse move) 를 하지 않았음에도
영상 이미지가 움직이게 되어 의도에 맞지 않게 동작합니다.

- [drag 영역이 document 로 잡혀있는 환경 링크](https://insight-viewer.s.lunit.io/interaction)

## ✔️ PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

drag interaction 시, mouse move, mouse up 에 대한 이벤트 범위가 document (전체 브라우저 영역) 입니다.

Issue Number: https://lunit.atlassian.net/browse/VIEWER-159

## 🚀 New behavior

drag interaction 시, mouse move, mouse up 에 대한 이벤트 범위가 viewer element (viewer 영역) 입니다.

mouse up, mouse move observable 의 영역을 `document` 에서 `element` 로 수정 20c6e86

move leave observable 추가 및 `rxjs merge + takeUntil` 를 이용하여 
mouse up, mouse leave 이벤트 발생 시, mouse move 의 구독을 끊습니다. 

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

