### PR TITLE
VIEWER-158 / Annotation, Interaction 동시 사용 불가 버그 수정

### DIFF
--- a/libs/annotation/src/hooks/useMouseEvent/index.ts
+++ b/libs/annotation/src/hooks/useMouseEvent/index.ts
@@ -13,10 +13,6 @@ export interface UseAnnotationEventParams {
   keyDownCallback: (event: KeyboardEvent) => void
 }
 
-const setPreProcessEvent = (event: MouseEvent | KeyboardEvent) => {
-  event.stopPropagation()
-}
-
 const useMouseEvent = ({
   mouseDownCallback,
   mouseMoveCallback,
@@ -33,8 +29,6 @@ const useMouseEvent = ({
     // Apply Drawing only when left mouse button is pressed
     if (event.button !== 0) return
 
-    setPreProcessEvent(event)
-
     const point = pageToPixel([event.pageX, event.pageY])
 
     mouseDownCallback(point)
@@ -44,29 +38,21 @@ const useMouseEvent = ({
     // Apply Drawing only when left mouse button is pressed
     if (event.button !== 0) return
 
-    setPreProcessEvent(event)
-
     const point = pageToPixel([event.pageX, event.pageY])
 
     mouseMoveCallback(point)
   }
 
-  const onMouseLeave = (event: MouseEvent) => {
-    setPreProcessEvent(event)
-
+  const onMouseLeave = () => {
     mouseLeaveCallback()
   }
 
-  const onMouseUp = (event: MouseEvent) => {
-    setPreProcessEvent(event)
-
+  const onMouseUp = () => {
     mouseUpCallback()
   }
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      setPreProcessEvent(event)
-
       keydownCallbackRef.current(event)
     }
 

--- a/libs/insight-viewer/src/hooks/useInteraction/useHandleDrag/index.ts
+++ b/libs/insight-viewer/src/hooks/useInteraction/useHandleDrag/index.ts
@@ -134,6 +134,7 @@ export default function useHandleDrag({ image, element, interaction, onViewportC
           }
         }),
         switchMap((start) => {
+          start.stopPropagation()
           let lastX = start.pageX
           let lastY = start.pageY
           const { top, left, width, height } = element.getBoundingClientRect()


### PR DESCRIPTION
## 📝 Description

Drag Interaction 과 Annotation Drawing 를 함께 사용할 시,
Image 가 움직이고, Annotation Drawing 이 함께 동작하는 버그를 수정합니다.

버그 수정 후 동작 방식은 다음과 같습니다.

Drag Interaction, Annotation Drawing 이 함께 실행될 경우,
Drag Interaction 이 우선 시 되며, Annotation Drawing 은 사용할 수 없습니다.
Drag Interaction 이 없을 경우, Annotation Drawing 은 사용 가능합니다.


## ✔️ PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

Drag Interaction, Annotation Drawing 이 동시에 발생합니다.

Issue Number: https://lunit.atlassian.net/browse/VIEWER-158

## 🚀 New behavior

Drag Interaction, Annotation Drawing 이 모두 활성화 되어 있을 경우,
Drag Interaction 만 발생합니다.

이에 대한 조치는 Drag Interaction 발생 시, `stopPropagation` 을 사용하여
이벤트가 캡처링/버블링 단계에서 전파되지 않도록 하여 하위에 있는 이벤트를 발생시키지 않도록
수정합니다.

- [stopPropagation MDN](https://developer.mozilla.org/ko/docs/Web/API/Event/stopPropagation)

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No

> If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
