### PR TITLE
VIEWER 160 / viewport subpath 에서 Viewport 관련 type export

### DIFF
--- a/apps/insight-viewer-dev/components/OverlayLayer/index.tsx
+++ b/apps/insight-viewer-dev/components/OverlayLayer/index.tsx
@@ -1,5 +1,5 @@
 import { Box, UnorderedList, ListItem } from '@chakra-ui/react'
-import { Viewport } from '@lunit/insight-viewer'
+import { Viewport } from '@lunit/insight-viewer/viewport'
 
 export default function OverlayLayer({
   viewport: { scale, hflip, vflip, x, y, invert, windowWidth, windowCenter, rotation },

--- a/apps/insight-viewer-dev/containers/Interaction/Canvas.tsx
+++ b/apps/insight-viewer-dev/containers/Interaction/Canvas.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { Viewport } from '@lunit/insight-viewer'
+import { Viewport } from '@lunit/insight-viewer/viewport'
 
 const style: React.CSSProperties = {
   position: 'absolute',

--- a/apps/insight-viewer-dev/containers/Overlay/Code.ts
+++ b/apps/insight-viewer-dev/containers/Overlay/Code.ts
@@ -3,7 +3,7 @@ export const CODE = `\
   import InsightViewer, { useImage } from '@lunit/insight-viewer'
   import { useViewport } from '@lunit/insight-viewer/viewport
 
-  import type { Viewport } from '@lunit/insight-viewer'
+  import type { Viewport } from '@lunit/insight-viewer/viewport'
 
   const style = {
     width: '500px',

--- a/apps/insight-viewer-dev/containers/UseOverlayContext/Contour/index.tsx
+++ b/apps/insight-viewer-dev/containers/UseOverlayContext/Contour/index.tsx
@@ -1,10 +1,12 @@
 import { useRef } from 'react'
 import { Box, Stack, Switch, Text } from '@chakra-ui/react'
 import { Resizable } from 're-resizable'
-import InsightViewer, { useImage, useInteraction, Viewport } from '@lunit/insight-viewer'
+import InsightViewer, { useImage, useInteraction } from '@lunit/insight-viewer'
 import { useViewport } from '@lunit/insight-viewer/viewport'
 import { IMAGES } from '@insight-viewer-library/fixtures'
 import Contour from './Contour'
+
+import type { Viewport } from '@lunit/insight-viewer/viewport'
 
 const style = {
   display: 'flex',

--- a/apps/insight-viewer-dev/containers/UseOverlayContext/Heatmap/index.tsx
+++ b/apps/insight-viewer-dev/containers/UseOverlayContext/Heatmap/index.tsx
@@ -2,11 +2,13 @@
 import { useRef } from 'react'
 import { Box, Stack, Switch, Text } from '@chakra-ui/react'
 import { Resizable } from 're-resizable'
-import InsightViewer, { useImage, useInteraction, Viewport, HeatmapViewer } from '@lunit/insight-viewer'
+import InsightViewer, { useImage, useInteraction, HeatmapViewer } from '@lunit/insight-viewer'
 import { useViewport } from '@lunit/insight-viewer/viewport'
 import { IMAGES } from '@insight-viewer-library/fixtures'
 import OverlayLayer from '../../../components/OverlayLayer'
 import posMap from './posMap'
+
+import type { Viewport } from '@lunit/insight-viewer/viewport'
 
 const style = {
   display: 'flex',

--- a/apps/insight-viewer-dev/containers/Viewport/Code.ts
+++ b/apps/insight-viewer-dev/containers/Viewport/Code.ts
@@ -3,7 +3,7 @@ import { useRef, useEffect, useCallback } from 'react'
 import InsightViewer, { useImage } from '@lunit/insight-viewer'
 import { useViewport } from '@lunit/insight-viewer/viewport'
 
-import type { Viewport } from '@lunit/insight-viewer'
+import type { Viewport } from '@lunit/insight-viewer/viewport'
 
 const style = {
   width: '500px',

--- a/apps/insight-viewer-dev/containers/Viewport/Image1.tsx
+++ b/apps/insight-viewer-dev/containers/Viewport/Image1.tsx
@@ -1,6 +1,6 @@
 import { useRef, useEffect, useCallback } from 'react'
 import { Box, Stack, Switch, Button } from '@chakra-ui/react'
-import InsightViewer, { useImage, Viewport } from '@lunit/insight-viewer'
+import InsightViewer, { useImage } from '@lunit/insight-viewer'
 import { useViewport } from '@lunit/insight-viewer/viewport'
 
 import { IMAGES } from '@insight-viewer-library/fixtures'
@@ -8,6 +8,8 @@ import { ViewerWrapper } from '../../components/Wrapper'
 import CustomProgress from '../../components/CustomProgress'
 import OverlayLayer from '../../components/OverlayLayer'
 import { INITIAL_VIEWPORT1 } from './const'
+
+import type { Viewport } from '@lunit/insight-viewer/viewport'
 
 export default function Image1(): JSX.Element {
   const viewerRef = useRef<HTMLDivElement>(null)

--- a/apps/insight-viewer-dev/containers/Viewport/Image2.tsx
+++ b/apps/insight-viewer-dev/containers/Viewport/Image2.tsx
@@ -1,12 +1,14 @@
 import { useRef, useEffect, useCallback } from 'react'
 import { Box, Stack, Button } from '@chakra-ui/react'
-import InsightViewer, { useImage, Viewport } from '@lunit/insight-viewer'
+import InsightViewer, { useImage } from '@lunit/insight-viewer'
 import { useViewport } from '@lunit/insight-viewer/viewport'
 import { IMAGES } from '@insight-viewer-library/fixtures'
 import { ViewerWrapper } from '../../components/Wrapper'
 import CustomProgress from '../../components/CustomProgress'
 import OverlayLayer from '../../components/OverlayLayer'
 import { INITIAL_VIEWPORT2 } from './const'
+
+import type { Viewport } from '@lunit/insight-viewer/viewport'
 
 export default function Image2(): JSX.Element {
   const viewerRef = useRef<HTMLDivElement>(null)

--- a/apps/insight-viewer-dev/containers/ViewportReset/MultiFrame/Code.ts
+++ b/apps/insight-viewer-dev/containers/ViewportReset/MultiFrame/Code.ts
@@ -3,7 +3,7 @@ import { useCallback, useRef } from 'react'
 import InsightViewer, { useMultipleImages, useFrame } from '@lunit/insight-viewer'
 import { useViewport } from '@lunit/insight-viewer/viewport'
 
-import type { Viewport } from '@lunit/insight-viewer'
+import type { Viewport } from '@lunit/insight-viewer/viewport'
 
 export default function Viewer() {
   const viewerRef = useRef<HTMLDivElement>(null)

--- a/apps/insight-viewer-dev/containers/ViewportReset/MultiFrame/Images.tsx
+++ b/apps/insight-viewer-dev/containers/ViewportReset/MultiFrame/Images.tsx
@@ -1,6 +1,6 @@
 import { useRef, useCallback } from 'react'
 import { Box, Stack, Switch, Button, Text } from '@chakra-ui/react'
-import InsightViewer, { useMultipleImages, useFrame, Viewport } from '@lunit/insight-viewer'
+import InsightViewer, { useMultipleImages, useFrame } from '@lunit/insight-viewer'
 import { useViewport } from '@lunit/insight-viewer/viewport'
 import { ViewerWrapper } from '../../../components/Wrapper'
 import CustomProgress from '../../../components/CustomProgress'
@@ -9,6 +9,8 @@ import useCaseSelect from './useCaseSelect'
 import CodeBlock from '../../../components/CodeBlock'
 
 import { BASE_CODE } from './Code'
+
+import type { Viewport } from '@lunit/insight-viewer/viewport'
 
 const INITIAL_VIEWPORT = {
   scale: 0.5,

--- a/apps/insight-viewer-dev/containers/ViewportReset/SingleFrame/Code.ts
+++ b/apps/insight-viewer-dev/containers/ViewportReset/SingleFrame/Code.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef } from 'react'
 import InsightViewer, { useImage } from '@lunit/insight-viewer'
 import { useViewport } from '@lunit/insight-viewer/viewport'
 
-import type { Viewport } from '@lunit/insight-viewer'
+import type { Viewport } from '@lunit/insight-viewer/viewport'
 
 // When changing the Image, the Viewport is always initialized.
 export default function Viewer() {

--- a/apps/insight-viewer-dev/containers/ViewportReset/SingleFrame/Image1.tsx
+++ b/apps/insight-viewer-dev/containers/ViewportReset/SingleFrame/Image1.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useRef } from 'react'
 import { Box, Stack, Switch, Button, Text } from '@chakra-ui/react'
-import InsightViewer, { useImage, Viewport } from '@lunit/insight-viewer'
+import InsightViewer, { useImage } from '@lunit/insight-viewer'
 import { useViewport } from '@lunit/insight-viewer/viewport'
 
 import useImageSelect from '../../../components/ImageSelect/useImageSelect'
@@ -10,6 +10,8 @@ import OverlayLayer from '../../../components/OverlayLayer'
 import CodeBlock from '../../../components/CodeBlock'
 
 import { RESET_VIEWPORT_CODE } from './Code'
+
+import type { Viewport } from '@lunit/insight-viewer/viewport'
 
 const INITIAL_VIEWPORT = {
   scale: 0.5,

--- a/apps/insight-viewer-dev/containers/ViewportReset/SingleFrame/Image2.tsx
+++ b/apps/insight-viewer-dev/containers/ViewportReset/SingleFrame/Image2.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react'
 import { Box, Stack, Switch, Button, Text } from '@chakra-ui/react'
-import InsightViewer, { useImage, Viewport } from '@lunit/insight-viewer'
+import InsightViewer, { useImage } from '@lunit/insight-viewer'
 import { useViewport } from '@lunit/insight-viewer/viewport'
 
 import useImageSelect from '../../../components/ImageSelect/useImageSelect'
@@ -10,6 +10,8 @@ import OverlayLayer from '../../../components/OverlayLayer'
 import CodeBlock from '../../../components/CodeBlock'
 
 import { NON_RESET_VIEWPORT_CODE } from './Code'
+
+import type { Viewport } from '@lunit/insight-viewer/viewport'
 
 const INITIAL_VIEWPORT = {
   scale: 0.5,

--- a/libs/viewport/src/index.ts
+++ b/libs/viewport/src/index.ts
@@ -1,2 +1,3 @@
 export { useViewport } from './useViewport'
 export type { SetViewportAction, UseViewportParams, UseViewportReturnType } from './useViewport/type'
+export type { Viewport, BasicViewport, ViewportOptions } from '@lunit/insight-viewer'


### PR DESCRIPTION
## 📝 Description

@lunit/insight-viewer/viewport 에서 Viewport 관련 타입을 import 할 수 있도록 수정합니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

Viewport 관련 type 을 import 할 때 아래와 같이 사용합니다.

```ts
import type { Viewport } from "@lunit/insight-viewer";
```

Issue Number: https://lunit.atlassian.net/browse/VIEWER-160

## 🚀 New behavior

Viewport 관련 type 을 import 할 때 아래와 같이 사용할 수 있습니다.

```ts
import type { Viewport } from "@lunit/insight-viewer/viewport";
```

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No
