### PR TITLE
VIEWER-54 / package.json 업데이트 및 viewer README 업데이트

### DIFF
--- a/libs/insight-viewer/README.md
+++ b/libs/insight-viewer/README.md
@@ -1,6 +1,168 @@
 # insight-viewer
 
-Managing the core logic of the Insight viewer library.<br />
-You can see how images are handled, how interactions are handled, how viewports are handled, and more.
+Insight Viewer is a library that [Cornerstone.js](https://github.com/cornerstonejs/cornerstone) medical image viewer component for React.
 
-> Please refer to the Root README for more information on how to use the library.
+- **Dicom Viewer**: Allows you to represent dicom image files in React.
+
+- **Dicom Viewport handling**: You can control the Dicom viewport declaratively.
+
+- **Drawing Annotation**: Supports the ability to draw annotations on Dicom images. <br />
+  This allows you to visually represent the location of a lesion.
+
+## Installation
+
+The insight viewer library is registered on NPM, so you can install and use it.
+
+- [@lunit/insight-viewer NPM](https://www.npmjs.com/package/@lunit/insight-viewer)
+
+## Getting started with INSIGHT Viewer
+
+Here is an examples of **Dicom Viewer**, **Interaction**, **Annotation Drawing**
+
+### Dicom Viewer
+
+If your purpose is to show a Dicom Image, you can use it as shown below.
+
+```tsx
+import InsightViewer, { useImage } from '@lunit/insight-viewer'
+
+const MOCK_IMAGE = 'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000002.dcm'
+
+export default function App() {
+  const { image } = useImage({ wadouri: MOCK_IMAGE })
+
+  return <InsightViewer image={image} />
+}
+```
+
+### Interaction
+
+If you want to manipulate the pan and adjustment of a Dicom Image through mouse events, you can use it as shown below.
+
+```tsx
+import { useRef } from 'react'
+import InsightViewer, { useImage, useInteraction } from '@lunit/insight-viewer'
+import { useViewport } from '@lunit/insight-viewer/viewport'
+
+type Controllers = {
+  pan: () => void
+  reset: () => void
+  adjust: () => void
+}
+
+const MOCK_IMAGE = 'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000002.dcm'
+
+export default function App() {
+  const viewerRef = useRef<HTMLDivElement | null>(null)
+  const { image } = useImage({ wadouri: MOCK_IMAGE })
+  const { interaction, setInteraction } = useInteraction({
+    mouseWheel: 'scale', // Dicom Image scale is changed by mouse wheel events.
+    primaryDrag: 'pan', // The Dicom Image is moved by the left mouse drag.
+  })
+  const { viewport, setViewport, resetViewport } = useViewport({ image, viewerRef })
+
+  const controllers: Controllers = {
+    pan: () => {
+      setInteraction((prev) => ({ ...prev, primaryDrag: 'pan' }))
+    },
+    reset: resetViewport, // Set to the initial viewport of the Dicom Image.
+    adjust: () => {
+      setInteraction((prev) => ({ ...prev, primaryDrag: 'adjust' }))
+    },
+  }
+
+  const viewerProps = {
+    image,
+    viewerRef,
+    viewport,
+    interaction,
+    onViewportChange: setViewport,
+  }
+
+  return (
+    <>
+      <button style={{ marginRight: '8px' }} onClick={controllers['pan']}>
+        pan
+      </button>
+      <button style={{ marginRight: '8px' }} onClick={controllers['adjust']}>
+        adjust
+      </button>
+      <button onClick={controllers['reset']}>reset</button>
+      <InsightViewer {...viewerProps} />
+    </>
+  )
+}
+```
+
+### Annotation Drawing
+
+If you want to draw annotations such as polygon, ruler, and area on a Dicom image, you can use the code below.
+
+```tsx
+import { useState } from 'react'
+import InsightViewer, { useImage } from '@lunit/insight-viewer'
+import { AnnotationOverlay } from '@lunit/insight-viewer/annotation'
+
+import type { Annotation, AnnotationMode } from '@lunit/insight-viewer/annotation'
+
+const MOCK_IMAGE = 'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000002.dcm'
+
+export default function App() {
+  const [annotationMode, setAnnotationMode] = useState<AnnotationMode>('polygon')
+  const [annotations, setAnnotation] = useState<Annotation[]>([])
+  const { image } = useImage({ wadouri: MOCK_IMAGE })
+
+  return (
+    <>
+      <button style={{ marginRight: '8px' }} onClick={() => setAnnotationMode('polygon')}>
+        polygon
+      </button>
+      <button style={{ marginRight: '8px' }} onClick={() => setAnnotationMode('ruler')}>
+        ruler
+      </button>
+      <button onClick={() => setAnnotationMode('area')}>area</button>
+      <InsightViewer image={image}>
+        <AnnotationOverlay
+          isDrawing
+          mode={annotationMode}
+          annotations={annotations}
+          onChange={(annotations) => setAnnotation(annotations)}
+        />
+      </InsightViewer>
+    </>
+  )
+}
+```
+
+## Docs
+
+You can see what features are supported and example code to use them.
+
+- [https://insight-viewer.lunit.io/](https://insight-viewer.lunit.io/)
+
+## Project structure
+
+- [`libs`](./libs) - Importable libraries.
+- [`apps`](./apps) - Applications that use libraries
+
+### Packages
+
+You can check out the library code deployed on NPM.
+
+- [`libs/insight-viewer`](./libs/insight-viewer) - Cornerstone.js medical image viewer component for React.
+
+### Testing Docs
+
+You can view documents created with the INSIGHT Viewer library.
+
+- [`apps/insight-viewer-dev`](./apps/insight-viewer-dev) - Documentation site for @lunit/insight-viewer.
+
+## Development
+
+Clone this repository locally `$ git clone git@github.com:lunit-io/insight-viewer.git`
+
+```sh
+$ npm i
+$ npm install -g nx
+$ npm start // serve docs on http://localhost:4200
+```

--- a/libs/insight-viewer/package.json
+++ b/libs/insight-viewer/package.json
@@ -1,7 +1,16 @@
 {
   "name": "@lunit/insight-viewer",
   "version": "7.0.0",
-  "description": "cornerstone 라이브러리를 기반으로 Dicom Image를 다루기 위한 여러 Component들을 제공한다.",
+  "author": "Lunit",
+  "keywords": [
+    "react",
+    "dicom",
+    "viewer",
+    "cornerstone"
+  ],
+  "repository": "github:lunit-io/insight-viewer",
+  "license": "MIT",
+  "description": "Based on the cornerstone library, it provides several components for handling Dicom images",
   "dependencies": {
     "polylabel": "^1.1.0"
   },

--- a/libs/insight-viewer/package.json
+++ b/libs/insight-viewer/package.json
@@ -9,6 +9,7 @@
     "cornerstone"
   ],
   "repository": "github:lunit-io/insight-viewer",
+  "homepage": "https://insight-viewer.lunit.io",
   "license": "MIT",
   "description": "Based on the cornerstone library, it provides several components for handling Dicom images",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,11 +5,25 @@
   "engines": {
     "node": ">=14.0.0"
   },
+  "nx": {
+    "targets": {
+      "publish": {
+        "dependsOn": [
+          {
+            "projects": "self",
+            "target": "build"
+          }
+        ]
+      }
+    }
+  },
   "scripts": {
     "start": "nx serve insight-viewer-dev",
     "release:minor": "nx run workspace:version --commitMessageFormat='chore(release): publish release' --releaseAs=minor",
     "release:major": "nx run workspace:version --commitMessageFormat='chore(release): publish release' --releaseAs=major",
-    "release:patch": "nx run workspace:version --commitMessageFormat='chore(release): publish release' --releaseAs=patch"
+    "release:patch": "nx run workspace:version --commitMessageFormat='chore(release): publish release' --releaseAs=patch",
+    "build": "nx run-many --target=build --projects=insight-viewer,annotation,viewport",
+    "publish": "node tools/scripts/publish.mjs"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## 📝 Description

insight-viewer 라이브러리의 package.json 과 README 를 업데이트합니다.
이를 통해 NPM 에 개시될 때 의도에 맞는 README 과 등록될 예정이며,
`keyword`, `repo`, `homepage` 정보가 표기됩니다.

- [package.json docs](https://docs.npmjs.com/cli/v9/configuring-npm/package-json)

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [x] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

Root 의 README 가 아닌 viewer 의 README 가 패키지가 포함됩니다.
이로 인해 의도와 다른 README 가 NPM 에 등록됩니다.

Issue Number: https://lunit.atlassian.net/browse/VIEWER-54

## 🚀 New behavior

viewer 의 업데이트된 README 가 NPM 에 등록됩니다.
이와 더불어 repo, homepage, keyword 정보가 NPM 에 표기됩니다.

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No
