### PR TITLE
VIEWER-162 / Annotation 추가 시 onAdd 의 값이 반영되지 않는 버그 해결

### DIFF
--- a/libs/annotation/src/components/AnnotationOverlay/utils/addAnnotation.ts
+++ b/libs/annotation/src/components/AnnotationOverlay/utils/addAnnotation.ts
@@ -33,5 +33,5 @@ export const addAnnotation =
       return
     }
 
-    onChange([...annotations, annotation])
+    onChange([...annotations, addedTargetAnnotation])
   }


### PR DESCRIPTION
## 📝 Description

Annotation 추가 시, `onAdd` 의 결과값이 `onChange` 에 반영되지 않는 이슈를 해결합니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

onAdd 의 값이 반영된 `addedTargetAnnotation` 를 사용하는 것이 아닌
처음 넘겨받은 pure Annotation 객체를 onChange 에 전달하고 있습니다.

위 방식으로 인해 onAdd 로 커스텀한 객체가 onChange 실행 시 전달되는 Annotations 배열에
반영되지 않습니다.

Issue Number: https://lunit.atlassian.net/browse/VIEWER-162

## 🚀 New behavior

onAdd 의 값이 반영된 `addedTargetAnnotation` 을 onChange 에 전달합니다.
이를 통해 onAdd 로 커스텀한 객체가 onChange 실행 시 전달되는 Annotations 배열에 반영됩니다.

유저는 onAdd props 를 통해 Annotation 객체에 필드를 유연하게 수정할 수 있습니다.

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No
