### PR TITLE
insight-viewer v8 Controlled Component

### DIFF
--- a/apps/insight-viewer/src/app/ControlledViewer.tsx
+++ b/apps/insight-viewer/src/app/ControlledViewer.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import { DicomViewer } from '@lunit-insight-viewer/react';
+
+import { imageIds, tools } from './image';
+
+import type { ViewerSnapshot } from '@lunit-insight-viewer/core';
+
+export function ControlledViewer() {
+  const [viewerInfo, setViewerInfo] = useState<ViewerSnapshot>(null);
+
+  const handleRotateButtonClick = () => {
+    if (!viewerInfo) return;
+
+    const clonedViewerInfo = { ...viewerInfo };
+
+    const { rotation } = clonedViewerInfo.viewport.getProperties();
+
+    clonedViewerInfo.viewport.setProperties({
+      rotation: typeof rotation === 'number' ? rotation + 30 : 0,
+    });
+
+    setViewerInfo(clonedViewerInfo);
+  };
+
+  const handleDicomViewerChange = (viewerInfo: ViewerSnapshot) => {
+    setViewerInfo(viewerInfo);
+  };
+
+  return (
+    <div style={{ width: '500px', height: '500px' }}>
+      <DicomViewer
+        tools={tools}
+        imageIds={imageIds}
+        viewerInfo={viewerInfo}
+        onChange={handleDicomViewerChange}
+      />
+      <button onClick={handleRotateButtonClick}>Move</button>
+    </div>
+  );
+}

--- a/apps/insight-viewer/src/app/ControlledViewer.tsx
+++ b/apps/insight-viewer/src/app/ControlledViewer.tsx
@@ -35,6 +35,10 @@ export function ControlledViewer() {
         onChange={handleDicomViewerChange}
       />
       <button onClick={handleRotateButtonClick}>Move</button>
+      <div style={{ marginBottom: '8px' }}>
+        {JSON.stringify(viewerInfo?.viewport.getProperties())}
+      </div>
+      <div>{JSON.stringify(viewerInfo?.viewport.getCamera())}</div>
     </div>
   );
 }

--- a/apps/insight-viewer/src/app/MultiViewer.tsx
+++ b/apps/insight-viewer/src/app/MultiViewer.tsx
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+import { DicomViewer } from '@lunit-insight-viewer/react';
+
+import { imageIds, imageIds2, tools } from './image';
+
+export function MultiViewer() {
+  return (
+    <MultiViewerWrapper>
+      <div style={{ display: 'flex', gap: 2, width: '500px', height: '500px' }}>
+        <DicomViewer imageIds={imageIds} tools={tools} />
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 2,
+          width: '500px',
+          height: '500px',
+        }}
+      >
+        <DicomViewer imageIds={imageIds2} tools={tools} />
+      </div>
+    </MultiViewerWrapper>
+  );
+}
+
+const MultiViewerWrapper = styled.div`
+  display: flex;
+  width: 100%;
+  height: 100%;
+`;

--- a/apps/insight-viewer/src/app/app.tsx
+++ b/apps/insight-viewer/src/app/app.tsx
@@ -1,72 +1,7 @@
-import { useState } from 'react';
-import { DicomViewer } from '@lunit-insight-viewer/react';
-
-import type { MappingToolWithKey } from '@lunit-insight-viewer/core';
-
-const imageIds = [
-  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000000.dcm',
-  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000001.dcm',
-  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000002.dcm',
-  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000003.dcm',
-  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000004.dcm',
-  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000005.dcm',
-  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000006.dcm',
-  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000007.dcm',
-  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000008.dcm',
-  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000009.dcm',
-  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000010.dcm',
-  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000011.dcm',
-  'wadouri:https://static.lunit.io/insight/samples/cxr/Nodule.dcm',
-  'wadouri:https://static.lunit.io/insight/samples/mmg/case01_LCC.dcm',
-];
-const imageIds2 = [
-  'wadouri:https://static.lunit.io/insight/samples/cxr/Nodule.dcm',
-  'wadouri:https://static.lunit.io/insight/samples/mmg/case01_LCC.dcm',
-  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000000.dcm',
-  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000001.dcm',
-  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000002.dcm',
-  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000003.dcm',
-  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000004.dcm',
-  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000005.dcm',
-  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000006.dcm',
-  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000007.dcm',
-  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000008.dcm',
-  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000009.dcm',
-  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000010.dcm',
-  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000011.dcm',
-  'wadouri:https://static.lunit.io/insight/samples/cxr/Nodule.dcm',
-  'wadouri:https://static.lunit.io/insight/samples/mmg/case01_LCC.dcm',
-];
-
-const tools: MappingToolWithKey[] = [
-  { tool: 'frame' },
-  { tool: 'pan' },
-  { tool: 'windowing' },
-  { tool: 'zoom' },
-];
+import { MultiViewer } from './MultiViewer';
 
 function App() {
-  const [value, setValue] = useState<boolean>(false);
-
-  return (
-    <div style={{ display: 'flex', gap: 10 }}>
-      <div style={{ display: 'flex', gap: 2, width: '500px', height: '500px' }}>
-        <DicomViewer imageIds={imageIds} tools={tools} />
-      </div>
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 2,
-          width: '500px',
-          height: '500px',
-        }}
-      >
-        <DicomViewer imageIds={value ? imageIds : imageIds2} tools={tools} />
-        <button onClick={() => setValue((prev) => !prev)}>스위치</button>
-      </div>
-    </div>
-  );
+  return <MultiViewer />;
 }
 
 export default App;

--- a/apps/insight-viewer/src/app/app.tsx
+++ b/apps/insight-viewer/src/app/app.tsx
@@ -1,7 +1,8 @@
+import { ControlledViewer } from './ControlledViewer';
 import { MultiViewer } from './MultiViewer';
 
 function App() {
-  return <MultiViewer />;
+  return <ControlledViewer />;
 }
 
 export default App;

--- a/apps/insight-viewer/src/app/image.ts
+++ b/apps/insight-viewer/src/app/image.ts
@@ -1,0 +1,43 @@
+import type { MappingToolWithKey } from '@lunit-insight-viewer/core';
+
+export const tools: MappingToolWithKey[] = [
+  { tool: 'frame' },
+  { tool: 'pan' },
+  { tool: 'windowing' },
+  { tool: 'zoom' },
+];
+
+export const imageIds = [
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000000.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000001.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000002.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000003.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000004.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000005.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000006.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000007.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000008.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000009.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000010.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000011.dcm',
+  'wadouri:https://static.lunit.io/insight/samples/cxr/Nodule.dcm',
+  'wadouri:https://static.lunit.io/insight/samples/mmg/case01_LCC.dcm',
+];
+export const imageIds2 = [
+  'wadouri:https://static.lunit.io/insight/samples/cxr/Nodule.dcm',
+  'wadouri:https://static.lunit.io/insight/samples/mmg/case01_LCC.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000000.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000001.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000002.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000003.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000004.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000005.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000006.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000007.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000008.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000009.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000010.dcm',
+  'wadouri:https://static.lunit.io/fixtures/dcm-files/series/CT000011.dcm',
+  'wadouri:https://static.lunit.io/insight/samples/cxr/Nodule.dcm',
+  'wadouri:https://static.lunit.io/insight/samples/mmg/case01_LCC.dcm',
+];

--- a/libs/core/src/Subscribable.ts
+++ b/libs/core/src/Subscribable.ts
@@ -4,9 +4,12 @@ type Listener = () => void;
  * Class for useSyncExternalStore for connecting with react
  * useSyncExternalStore Docs: https://react.dev/reference/react/useSyncExternalStore
  */
-export class Subscribable<TListener extends Function = Listener> {
-  protected listeners: Set<TListener>;
-  protected snapshot: unknown;
+export abstract class Subscribable<
+  TSnapshot,
+  KListener extends Function = Listener
+> {
+  protected listeners: Set<KListener>;
+  protected abstract snapshot: TSnapshot;
 
   constructor() {
     this.listeners = new Set();
@@ -38,7 +41,7 @@ export class Subscribable<TListener extends Function = Listener> {
     return this.snapshot;
   };
 
-  subscribe(listener: TListener): () => void {
+  subscribe(listener: KListener): () => void {
     this.listeners.add(listener);
 
     this.onSubscribe();

--- a/libs/core/src/Subscribable.ts
+++ b/libs/core/src/Subscribable.ts
@@ -6,7 +6,7 @@ type Listener = () => void;
  */
 export abstract class Subscribable<
   TSnapshot,
-  KListener extends Function = Listener
+  KListener extends (...args: unknown[]) => void = Listener
 > {
   protected listeners: Set<KListener>;
   protected abstract snapshot: TSnapshot;

--- a/libs/core/src/eventHandler/EventHandler.ts
+++ b/libs/core/src/eventHandler/EventHandler.ts
@@ -1,7 +1,5 @@
 import { EVENTS } from '@cornerstonejs/core';
 
-import type { Types } from '@cornerstonejs/core';
-
 const { IMAGE_RENDERED } = EVENTS;
 
 /**
@@ -14,11 +12,7 @@ export class EventHandler {
     element: HTMLDivElement,
     callback: () => void
   ) => {
-    element.addEventListener(IMAGE_RENDERED, ((
-      _: Types.EventTypes.ImageRenderedEvent
-    ) => {
-      callback();
-    }) as EventListener);
+    element.addEventListener(IMAGE_RENDERED, callback);
   };
 
   init = (element: HTMLDivElement, callback: () => void) => {

--- a/libs/core/src/renderViewport/RenderingStackViewport.ts
+++ b/libs/core/src/renderViewport/RenderingStackViewport.ts
@@ -40,6 +40,13 @@ export class RenderingStackViewport extends ViewerSlot {
     this.renderingEngine?.disableElement(this.viewportId);
   };
 
+  setViewport = (viewport: StackViewport): void => {
+    if (!this.viewport || !this.renderingEngine) return;
+
+    this.viewport = viewport;
+    this.render();
+  };
+
   resetViewport = (): void => {
     if (!this.viewport) return;
 

--- a/libs/core/src/viewerFactory/ViewerFactory.ts
+++ b/libs/core/src/viewerFactory/ViewerFactory.ts
@@ -77,6 +77,5 @@ export class ViewerFactory extends Subscribable<ViewerSnapshot> {
     if (!viewerInfo) return;
 
     this.RenderingStackViewport.setViewport(viewerInfo.viewport);
-    this.emitChange();
   };
 }

--- a/libs/core/src/viewerFactory/ViewerFactory.ts
+++ b/libs/core/src/viewerFactory/ViewerFactory.ts
@@ -62,7 +62,10 @@ export class ViewerFactory extends Subscribable<ViewerSnapshot> {
     tools?: MappingToolWithKey[],
     eventCallback?: (viewerInfo: ViewerSnapshot) => void
   ) => {
-    this.EventHandler.init(element, () => eventCallback?.(this.getSnapshot()));
+    this.EventHandler.init(element, () => {
+      this.setSnapshot();
+      eventCallback?.(this.snapshot);
+    });
 
     await this.RenderingStackViewport.init(element, imageIds);
     await this.ToolManager.init(element, tools);

--- a/libs/core/src/viewerFactory/ViewerFactory.ts
+++ b/libs/core/src/viewerFactory/ViewerFactory.ts
@@ -59,11 +59,21 @@ export class ViewerFactory extends Subscribable<ViewerSnapshot> {
   init = async (
     element: HTMLDivElement,
     imageIds: string[],
-    tools?: MappingToolWithKey[]
+    tools?: MappingToolWithKey[],
+    eventCallback?: (viewerInfo: ViewerSnapshot) => void
   ) => {
+    this.EventHandler.init(element, () => eventCallback?.(this.getSnapshot()));
+
     await this.RenderingStackViewport.init(element, imageIds);
     await this.ToolManager.init(element, tools);
-    this.EventHandler.init(element, this.emitChange);
+
+    this.emitChange();
+  };
+
+  updateSnapshot = (viewerInfo: ViewerSnapshot) => {
+    if (!viewerInfo) return;
+
+    this.RenderingStackViewport.setViewport(viewerInfo.viewport);
     this.emitChange();
   };
 }

--- a/libs/core/src/viewerFactory/ViewerFactory.ts
+++ b/libs/core/src/viewerFactory/ViewerFactory.ts
@@ -15,12 +15,12 @@ export type ViewerStatus = {
 export type ViewerSnapshot = ViewerStatus | null;
 
 // TODO: Need to refactor common behaviours like subscribe
-export class ViewerFactory extends Subscribable {
+export class ViewerFactory extends Subscribable<ViewerSnapshot> {
   private viewerId: string;
   private ToolManager: ToolManager;
   private RenderingStackViewport: RenderingStackViewport;
   private EventHandler: EventHandler;
-  protected override snapshot: ViewerSnapshot;
+  protected snapshot: ViewerSnapshot;
 
   constructor() {
     super();

--- a/libs/react-dicom-viewer/src/DicomViewer.tsx
+++ b/libs/react-dicom-viewer/src/DicomViewer.tsx
@@ -2,20 +2,32 @@ import { useState, useCallback } from 'react';
 
 import { useStackViewport } from './useStackViewport';
 
-import type { MappingToolWithKey } from '@lunit-insight-viewer/core';
+import type {
+  ViewerSnapshot,
+  MappingToolWithKey,
+} from '@lunit-insight-viewer/core';
 
 interface DicomViewerProps {
   imageIds: string[];
   tools?: MappingToolWithKey[];
+  viewerInfo?: ViewerSnapshot;
+  onChange?: (viewerInfo: ViewerSnapshot) => void;
 }
 
-export function DicomViewer({ imageIds, tools }: DicomViewerProps) {
+export function DicomViewer({
+  imageIds,
+  tools,
+  viewerInfo,
+  onChange,
+}: DicomViewerProps) {
   const { dicomViewerWrapper, ref } = useDicomViewerElement();
 
   useStackViewport({
     element: dicomViewerWrapper,
     imageIds,
     tools,
+    viewerInfo,
+    onChange,
   });
 
   return (

--- a/libs/react-dicom-viewer/src/useStackViewport.ts
+++ b/libs/react-dicom-viewer/src/useStackViewport.ts
@@ -29,11 +29,9 @@ export const useStackViewport = ({
     viewerFactoryRef.current = new ViewerFactory();
   }
 
-  const subscribe = useCallback(
-    (listener: () => void) => () =>
-      viewerFactoryRef!.current?.subscribe(listener),
-    []
-  );
+  const subscribe = (listener: () => void) => () => {
+    viewerFactoryRef!.current?.subscribe(listener);
+  };
 
   useSyncExternalStore(subscribe, viewerFactoryRef!.current.getSnapshot);
 

--- a/libs/react-dicom-viewer/src/useStackViewport.ts
+++ b/libs/react-dicom-viewer/src/useStackViewport.ts
@@ -1,19 +1,27 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { useRef, useEffect, useCallback, useSyncExternalStore } from 'react';
 
 import { ViewerFactory } from '@lunit-insight-viewer/core';
 
-import type { MappingToolWithKey } from '@lunit-insight-viewer/core';
+import type {
+  ViewerSnapshot,
+  MappingToolWithKey,
+} from '@lunit-insight-viewer/core';
 
 interface UseStackViewportParams {
   element: HTMLDivElement | null;
   imageIds: string[];
   tools?: MappingToolWithKey[];
+  viewerInfo?: ViewerSnapshot;
+  onChange?: (viewerInfo: ViewerSnapshot) => void;
 }
 
 export const useStackViewport = ({
   element,
   imageIds,
   tools,
+  viewerInfo,
+  onChange,
 }: UseStackViewportParams) => {
   const viewerFactoryRef = useRef<ViewerFactory | null>(null);
 
@@ -24,7 +32,7 @@ export const useStackViewport = ({
   const subscribe = useCallback(
     (listener: () => void) => () =>
       viewerFactoryRef!.current?.subscribe(listener),
-    [element]
+    []
   );
 
   useSyncExternalStore(subscribe, viewerFactoryRef!.current.getSnapshot);
@@ -32,10 +40,36 @@ export const useStackViewport = ({
   useEffect(() => {
     const renderingWithInitialSettings = async () => {
       if (viewerFactoryRef.current && element) {
-        await viewerFactoryRef.current.init(element, imageIds, tools);
+        const eventCallback = (viewerInfo: ViewerSnapshot) => {
+          onChange?.(viewerInfo);
+        };
+
+        await viewerFactoryRef.current.init(
+          element,
+          imageIds,
+          tools,
+          eventCallback
+        );
       }
     };
 
     renderingWithInitialSettings();
-  }, [element, imageIds, viewerFactoryRef.current]);
+    /**
+     * Adding onChange will most likely cause infinite rendering issues
+     * If you assign a function to onChange
+     * that doesn't have a useCallback and is generated on every render,
+     * it will cause Causes infinite rendering
+     */
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [element, imageIds, tools]);
+
+  useEffect(() => {
+    if (!viewerInfo || !viewerFactoryRef.current) return;
+
+    const currentSnapshot = viewerFactoryRef.current.getSnapshot();
+
+    if (currentSnapshot === viewerInfo) return;
+
+    viewerFactoryRef.current.updateSnapshot(viewerInfo);
+  }, [viewerInfo]);
 };

--- a/libs/react-dicom-viewer/src/useStackViewport.ts
+++ b/libs/react-dicom-viewer/src/useStackViewport.ts
@@ -39,6 +39,8 @@ export const useStackViewport = ({
   );
 
   useEffect(() => {
+    if (viewerInfo) return;
+
     const renderingWithInitialSettings = async () => {
       if (viewerFactoryRef.current && element) {
         const eventCallback = (viewerInfo: ViewerSnapshot) => {
@@ -55,14 +57,7 @@ export const useStackViewport = ({
     };
 
     renderingWithInitialSettings();
-    /**
-     * Adding onChange will most likely cause infinite rendering issues
-     * If you assign a function to onChange
-     * that doesn't have a useCallback and is generated on every render,
-     * it will cause Causes infinite rendering
-     */
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [element, imageIds, tools]);
+  }, [element, imageIds, tools, viewerInfo, onChange]);
 
   useEffect(() => {
     if (!viewerInfo || !viewerFactoryRef.current) return;

--- a/libs/react-dicom-viewer/src/useStackViewport.ts
+++ b/libs/react-dicom-viewer/src/useStackViewport.ts
@@ -61,7 +61,6 @@ export const useStackViewport = ({
 
   useEffect(() => {
     if (!viewerInfo || !viewerFactoryRef.current) return;
-
     if (snapshot === viewerInfo) return;
 
     viewerFactoryRef.current.updateSnapshot(viewerInfo);

--- a/libs/react-dicom-viewer/src/useStackViewport.ts
+++ b/libs/react-dicom-viewer/src/useStackViewport.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { useRef, useEffect, useCallback, useSyncExternalStore } from 'react';
+import { useRef, useEffect, useSyncExternalStore } from 'react';
 
 import { ViewerFactory } from '@lunit-insight-viewer/core';
 

--- a/libs/react-dicom-viewer/src/useStackViewport.ts
+++ b/libs/react-dicom-viewer/src/useStackViewport.ts
@@ -40,23 +40,9 @@ export const useStackViewport = ({
 
   useEffect(() => {
     if (viewerInfo) return;
+    if (!viewerFactoryRef.current || !element) return;
 
-    const renderingWithInitialSettings = async () => {
-      if (viewerFactoryRef.current && element) {
-        const eventCallback = (viewerInfo: ViewerSnapshot) => {
-          onChange?.(viewerInfo);
-        };
-
-        await viewerFactoryRef.current.init(
-          element,
-          imageIds,
-          tools,
-          eventCallback
-        );
-      }
-    };
-
-    renderingWithInitialSettings();
+    viewerFactoryRef.current.init(element, imageIds, tools, onChange);
   }, [element, imageIds, tools, viewerInfo, onChange]);
 
   useEffect(() => {

--- a/libs/react-dicom-viewer/src/useStackViewport.ts
+++ b/libs/react-dicom-viewer/src/useStackViewport.ts
@@ -33,7 +33,10 @@ export const useStackViewport = ({
     viewerFactoryRef!.current?.subscribe(listener);
   };
 
-  useSyncExternalStore(subscribe, viewerFactoryRef!.current.getSnapshot);
+  const snapshot = useSyncExternalStore(
+    subscribe,
+    viewerFactoryRef!.current.getSnapshot
+  );
 
   useEffect(() => {
     const renderingWithInitialSettings = async () => {
@@ -64,10 +67,8 @@ export const useStackViewport = ({
   useEffect(() => {
     if (!viewerInfo || !viewerFactoryRef.current) return;
 
-    const currentSnapshot = viewerFactoryRef.current.getSnapshot();
-
-    if (currentSnapshot === viewerInfo) return;
+    if (snapshot === viewerInfo) return;
 
     viewerFactoryRef.current.updateSnapshot(viewerInfo);
-  }, [viewerInfo]);
+  }, [viewerInfo, snapshot]);
 };


### PR DESCRIPTION
## 📝 Description

`DicomViewer` 를 React Controlled Component 로 사용할 수 있도록 기능을 구현합니다.

### 구현 사항

1. pan, zoom 과 같이 DICOM 에 변경이 있을 경우, `onChange` 를 호출하여 상태를 업데이트 합니다.
2. `DicomViewer` 의 viewerInfo prop 의 값이 변경될 경우, 이를 이미지에 반영하여 리렌더링 합니다.

### 구현 방식

- `useStackViewport` 에서 useEffect 를 통해 eventCallback 함수로 onChange 를 할당했습니다.
- `useStackViewport` 에서 useEffect 를 통해 viewerInfo prop 이 변경될 경우, viewerFactory 의 `updateSnapshot` 을 호출합니다.
- `viewerFactory` 의 `updateSnapshot` 을 통해 viewport 를 업데이트 합니다.

### 확인 요청 사항

- [ ] `npm run start:docs` 를 통해 DicomViewer 가 정상 렌더링 되는지 확인 부탁드립니다.
- [ ] DicomViewer 에서 Move 버튼을 클릭하면 이미지가 회전하는지 확인 부탁드립니다.
- [ ] 이미지 회전과 동시에 리렌더링 + 아래 이미지 상태 text 가 변경되는지 확인 부탁드립니다.
- [ ] Move 버튼과 별개로 Dicom 이미지의 pan, zoom 기능을 사용했을 때도 위 동작을 하는지 확인 부탁드립니다.

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

N/A

Issue Number: N/A

## 🚀 New behavior

`DicomViewer` 가 Controlled Component 형태로 동작합니다.


https://github.com/user-attachments/assets/a0a5a327-4782-4bd2-adc8-0cc7acf0a466


## 💣 Is this a breaking change?

- [ ] Yes
- [x] No
