### PR TITLE
[VIEWER-169] DicomViewer default style 적용

### DIFF
--- a/libs/react-dicom-viewer/src/DicomViewer.tsx
+++ b/libs/react-dicom-viewer/src/DicomViewer.tsx
@@ -2,7 +2,8 @@ import { useDicomViewer } from './useDicomViewer';
 
 interface DicomViewerProps {
   imageIds: string[];
-  style?: React.CSSProperties;
+  width?: React.CSSProperties['width'];
+  height?: React.CSSProperties['height'];
 }
 
 export const DicomViewer = (props: DicomViewerProps) => {
@@ -14,7 +15,7 @@ export const DicomViewer = (props: DicomViewerProps) => {
     <div
       ref={viewerElementRef}
       id="dicom-viewer-wrapper"
-      style={{ width: '500px', height: '500px', ...props.style }}
+      style={{ width: props.width ?? '500px', height: props.height ?? '500px' }}
     />
   );
 };

--- a/libs/react-dicom-viewer/src/DicomViewer.tsx
+++ b/libs/react-dicom-viewer/src/DicomViewer.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useDicomViewer } from './useDicomViewer';
 
 interface DicomViewerProps {
@@ -11,11 +12,18 @@ export const DicomViewer = (props: DicomViewerProps) => {
     imageIds: props.imageIds ?? [],
   });
 
+  const memoizedViewerElementStyle = useMemo(() => {
+    return {
+      width: props.width ?? '500px',
+      height: props.height ?? '500px',
+    };
+  }, [props.width, props.height]);
+
   return (
     <div
       ref={viewerElementRef}
       id="dicom-viewer-wrapper"
-      style={{ width: props.width ?? '500px', height: props.height ?? '500px' }}
+      style={memoizedViewerElementStyle}
     />
   );
 };

--- a/libs/react-dicom-viewer/src/DicomViewer.tsx
+++ b/libs/react-dicom-viewer/src/DicomViewer.tsx
@@ -1,7 +1,8 @@
 import { useDicomViewer } from './useDicomViewer';
 
 interface DicomViewerProps {
-  imageIds?: string[];
+  imageIds: string[];
+  style?: React.CSSProperties;
 }
 
 export const DicomViewer = (props: DicomViewerProps) => {
@@ -13,7 +14,7 @@ export const DicomViewer = (props: DicomViewerProps) => {
     <div
       ref={viewerElementRef}
       id="dicom-viewer-wrapper"
-      style={{ width: '100%', height: '100%' }}
+      style={{ width: '500px', height: '500px', ...props.style }}
     />
   );
 };


### PR DESCRIPTION
## 📝 Description

v7 의 `InsightViewer`, v8 의 `DicomViewer` 모두, 
사용 시 상위 element 에서 viewer 의 width, height 를 지정하는 과정을 거쳐야합니다.

이는 사용성 저하의 원인 중 하나로 v8 의 `DicomViewer` 는 기본적인 width, height 를 지정하여
사용자가 style wrapper element 를 선언하지 않고, `DicomViewer` 를 독립적으로 사용할 수 있도록
개선합니다.


## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior

사용자는 `DicomViewer` 를 사용하기 위해 상위 Wrapper 선언 및 스타일 지정이 필요합니다.

Issue Number: N/A

## 🚀 New behavior

사용자는 상위 Wrapper 선언 없이 `DicomViewer` 을 독립적으로 사용할 수 있습니다.
